### PR TITLE
feat: add record list with localStorage persistence

### DIFF
--- a/src/app/components/ResultDialog.tsx
+++ b/src/app/components/ResultDialog.tsx
@@ -8,16 +8,19 @@ import {
 } from "@/components/ui/dialog";
 import { Calculator } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { Result } from "@/types/trade";
+import type { Result, TradeInput } from "@/types/trade";
 import { formatNumber } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   result: Result | null;
+  input?: TradeInput;
+  onGoHome?: () => void;
 };
 
-const ResultDialog = ({ open, onOpenChange, result }: Props) => {
+const ResultDialog = ({ open, onOpenChange, result, input, onGoHome }: Props) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -36,7 +39,7 @@ const ResultDialog = ({ open, onOpenChange, result }: Props) => {
             >
               {result.message}
             </p>
-            <div className="space-y-1">
+            <div className="space-y-1 text-sm">
               <p>原始買入金額：{formatNumber(result.buyAmount)}</p>
               <p>買入手續費：{formatNumber(result.buyFee)}</p>
               <p>
@@ -49,14 +52,10 @@ const ResultDialog = ({ open, onOpenChange, result }: Props) => {
                   {formatNumber(result.sellAmount)}
                 </span>
               </p>
-              <p>
-                賣出手續費：
-                <span>{formatNumber(result.sellFee)}</span>
-              </p>
-              <p>
-                交易稅金：
-                <span>{formatNumber(result.tax)}</span>
-              </p>
+              <p>賣出手續費：{formatNumber(result.sellFee)}</p>
+              <p>交易稅金：{formatNumber(result.tax)}</p>
+              <p>成本：{formatNumber(result.cost)}</p>
+              <p>收益：{formatNumber(result.revenue)}</p>
               <p>
                 淨盈虧：
                 <span
@@ -68,7 +67,31 @@ const ResultDialog = ({ open, onOpenChange, result }: Props) => {
                   {formatNumber(result.netProfit)}
                 </span>
               </p>
+              <p>換算工作天數：{result.workDays} 天</p>
             </div>
+
+            {input && (
+              <div className="space-y-1 pt-2 border-t text-sm">
+                <p>
+                  薪資類型：
+                  {input.salaryType === "yearly"
+                    ? "年薪"
+                    : input.salaryType === "monthly"
+                      ? "月薪"
+                      : "時薪"}
+                </p>
+                <p>薪資：{formatNumber(input.salary)}</p>
+                {input.salaryType === "hourly" && (
+                  <p>每日工時：{input.hoursPerDay} 小時</p>
+                )}
+              </div>
+            )}
+
+            {onGoHome && (
+              <div className="pt-4 flex justify-center">
+                <Button onClick={onGoHome}>回首頁</Button>
+              </div>
+            )}
           </div>
         )}
       </DialogContent>

--- a/src/app/components/TradeForm.tsx
+++ b/src/app/components/TradeForm.tsx
@@ -79,6 +79,11 @@ const TradeForm = ({
         <Button className="w-full" variant="outline" onClick={onOpenSalary}>
           <Settings className="w-4 h-4 mr-2" /> 薪資設定
         </Button>
+        {isInvalid && (
+          <p className="text-xs text-red-500 text-center">
+            請輸入買入價格、賣出價格與股數
+          </p>
+        )}
         <Button className="w-full" disabled={isInvalid} onClick={onCalculate}>
           <Calculator className="w-5 h-5 mr-2" /> 立即換算成工作日數
         </Button>

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Github } from "lucide-react";
+import TradeForm from "../components/TradeForm";
+import SalaryDialog from "../components/SalaryDialog";
+import ResultDialog from "../components/ResultDialog";
+import { calculateResult } from "@/lib/utils";
+import { useRouter } from "next/navigation";
+
+import type {
+  SalaryType,
+  Result,
+  TradeInput,
+  TradeRecord,
+} from "@/types/trade";
+
+const STORAGE_KEY = "workdayCalc:records";
+
+export default function App() {
+  // Trade form
+  const [buyPrice, setBuyPrice] = useState<number | "">("");
+  const [sellPrice, setSellPrice] = useState<number | "">("");
+  const [shares, setShares] = useState<number | "">(1000);
+
+  // Salary settings
+  const [salary, setSalary] = useState<number>(190);
+  const [salaryType, setSalaryType] = useState<SalaryType>("hourly");
+  const [hoursPerDay, setHoursPerDay] = useState<number>(8);
+
+  // Modal controls
+  const [isSalaryModalOpen, setIsSalaryModalOpen] = useState(false);
+  const [isResultModalOpen, setIsResultModalOpen] = useState(false);
+
+  // Calculation result
+  const [result, setResult] = useState<Result | null>(null);
+
+  const [storageError, setStorageError] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    try {
+      localStorage.getItem(STORAGE_KEY);
+    } catch (e) {
+      setStorageError(true);
+    }
+  }, []);
+
+  const isInvalid = !buyPrice || !sellPrice || !shares;
+
+  const saveRecord = (input: TradeInput, res: Result) => {
+    if (storageError) return;
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const records: TradeRecord[] = raw ? JSON.parse(raw) : [];
+      const newRecord: TradeRecord = {
+        id:
+          typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : Date.now().toString(),
+        createdAt: Date.now(),
+        input,
+        result: res,
+      };
+      records.unshift(newRecord);
+      if (records.length > 100) records.pop();
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+    } catch (e) {
+      setStorageError(true);
+    }
+  };
+
+  const calculate = () => {
+    if (isInvalid) return;
+
+    const input: TradeInput = {
+      buyPrice: buyPrice as number,
+      sellPrice: sellPrice as number,
+      shares: shares as number,
+      salary,
+      salaryType,
+      hoursPerDay,
+    };
+
+    const res = calculateResult(input);
+    if (!res) return;
+
+    saveRecord(input, res);
+
+    setResult(res);
+    setIsResultModalOpen(true);
+  };
+
+  return (
+    <div className="max-w-lg mx-auto p-4">
+      <h1 className="text-2xl font-bold text-center mb-6">新增計算</h1>
+      {storageError && (
+        <p className="text-red-500 text-sm text-center mb-4">
+          無法存取本機儲存，此次結果不會被保存
+        </p>
+      )}
+
+      <TradeForm
+        buyPrice={buyPrice}
+        sellPrice={sellPrice}
+        shares={shares}
+        onBuyChange={setBuyPrice}
+        onSellChange={setSellPrice}
+        onSharesChange={setShares}
+        onCalculate={calculate}
+        onOpenSalary={() => setIsSalaryModalOpen(true)}
+        isInvalid={isInvalid}
+      />
+
+      <SalaryDialog
+        open={isSalaryModalOpen}
+        onOpenChange={setIsSalaryModalOpen}
+        salary={salary}
+        salaryType={salaryType}
+        hoursPerDay={hoursPerDay}
+        onSalaryChange={setSalary}
+        onTypeChange={setSalaryType}
+        onHoursChange={setHoursPerDay}
+      />
+
+      <ResultDialog
+        open={isResultModalOpen}
+        onOpenChange={setIsResultModalOpen}
+        result={result}
+        input={{
+          buyPrice: buyPrice as number,
+          sellPrice: sellPrice as number,
+          shares: shares as number,
+          salary,
+          salaryType,
+          hoursPerDay,
+        }}
+        onGoHome={() => router.push("/")}
+      />
+
+      <a
+        href="https://github.com/HappyJayXin/work-day-calc"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="fixed bottom-4 right-4 bg-black text-white rounded-full p-3 shadow-lg hover:bg-gray-800 transition-colors"
+        title="View on GitHub"
+      >
+        <Github className="w-5 h-5" />
+      </a>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,87 +1,113 @@
 "use client";
 
-import { useState } from "react";
-import { Github } from "lucide-react";
-import TradeForm from "./components/TradeForm";
-import SalaryDialog from "./components/SalaryDialog";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import ResultDialog from "./components/ResultDialog";
-import { calculateResult } from "@/lib/utils";
+import { cn, formatNumber } from "@/lib/utils";
+import type { TradeRecord } from "@/types/trade";
+import { Github } from "lucide-react";
 
-import type { SalaryType, Result } from "@/types/trade";
+const STORAGE_KEY = "workdayCalc:records";
 
-export default function App() {
-  // Trade form
-  const [buyPrice, setBuyPrice] = useState<number | "">("");
-  const [sellPrice, setSellPrice] = useState<number | "">("");
-  const [shares, setShares] = useState<number | "">(1000);
+export default function HomePage() {
+  const [records, setRecords] = useState<TradeRecord[]>([]);
+  const [storageError, setStorageError] = useState(false);
+  const [selected, setSelected] = useState<TradeRecord | null>(null);
 
-  // Salary settings
-  const [salary, setSalary] = useState<number>(190);
-  const [salaryType, setSalaryType] = useState<SalaryType>("hourly");
-  const [hoursPerDay, setHoursPerDay] = useState<number>(8);
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as TradeRecord[];
+        parsed.sort((a, b) => b.createdAt - a.createdAt);
+        setRecords(parsed);
+      }
+    } catch (e) {
+      setStorageError(true);
+    }
+  }, []);
 
-  // Modal controls
-  const [isSalaryModalOpen, setIsSalaryModalOpen] = useState(false);
-  const [isResultModalOpen, setIsResultModalOpen] = useState(false);
-
-  // Calculation result
-  const [result, setResult] = useState<Result | null>(null);
-
-  const isInvalid = !buyPrice || !sellPrice || !shares;
-
-  const calculate = () => {
-    if (isInvalid) return;
-
-    const res = calculateResult({
-      buyPrice,
-      sellPrice,
-      shares,
-      salary,
-      salaryType,
-      hoursPerDay,
-    });
-    if (!res) return;
-
-    setResult(res);
-    setIsResultModalOpen(true);
+  const removeRecord = (id: string) => {
+    const updated = records.filter((r) => r.id !== id);
+    setRecords(updated);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+    } catch (e) {
+      setStorageError(true);
+    }
   };
 
   return (
     <div className="max-w-lg mx-auto p-4">
       <h1 className="text-2xl font-bold text-center mb-6">工作日換算工具</h1>
-      <p className="text-sm text-muted-foreground text-center mb-8">
-        將股票交易的盈虧金額轉換為「可以少工作幾天」或「需要加班幾天」
-      </p>
-
-      <TradeForm
-        buyPrice={buyPrice}
-        sellPrice={sellPrice}
-        shares={shares}
-        onBuyChange={setBuyPrice}
-        onSellChange={setSellPrice}
-        onSharesChange={setShares}
-        onCalculate={calculate}
-        onOpenSalary={() => setIsSalaryModalOpen(true)}
-        isInvalid={isInvalid}
-      />
-
-      <SalaryDialog
-        open={isSalaryModalOpen}
-        onOpenChange={setIsSalaryModalOpen}
-        salary={salary}
-        salaryType={salaryType}
-        hoursPerDay={hoursPerDay}
-        onSalaryChange={setSalary}
-        onTypeChange={setSalaryType}
-        onHoursChange={setHoursPerDay}
-      />
-
-      <ResultDialog
-        open={isResultModalOpen}
-        onOpenChange={setIsResultModalOpen}
-        result={result}
-      />
-
+      {storageError && (
+        <p className="text-red-500 text-sm text-center mb-4">
+          無法存取本機儲存
+        </p>
+      )}
+      <div className="mb-4 flex justify-center">
+        <Button asChild>
+          <Link href="/new">新增</Link>
+        </Button>
+      </div>
+      {records.length === 0 ? (
+        <p className="text-center text-muted-foreground">尚無紀錄</p>
+      ) : (
+        <ul className="space-y-4">
+          {records.map((r) => (
+            <li key={r.id} className="border p-4 rounded-md">
+              <div className="flex justify-between items-start gap-4">
+                <div className="space-y-1">
+                  <p className="text-sm">
+                    {new Date(r.createdAt).toLocaleString("zh-TW")}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    買 {r.input.buyPrice} / 賣 {r.input.sellPrice} / 股數 {r.input.shares}
+                  </p>
+                  <p
+                    className={cn(
+                      r.result.netProfit >= 0
+                        ? "text-green-600"
+                        : "text-red-500",
+                      "text-sm"
+                    )}
+                  >
+                    淨損益 {formatNumber(r.result.netProfit)}
+                  </p>
+                  <p className="text-sm">換算 {r.result.workDays} 天</p>
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setSelected(r)}
+                  >
+                    查看
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      if (confirm("確定刪除這筆紀錄？")) removeRecord(r.id);
+                    }}
+                  >
+                    刪除
+                  </Button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      {selected && (
+        <ResultDialog
+          open={!!selected}
+          onOpenChange={(open) => !open && setSelected(null)}
+          result={selected.result}
+          input={selected.input}
+        />
+      )}
       <a
         href="https://github.com/HappyJayXin/work-day-calc"
         target="_blank"

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -17,6 +17,7 @@ describe("calculateResult", () => {
     });
     expect(result?.message).toBe("🎉 你可以少工作 3 天");
     expect(result?.netProfit).toBeGreaterThan(0);
+    expect(result?.workDays).toBe(3);
   });
 
   it("handles yearly salary with loss", () => {
@@ -29,6 +30,7 @@ describe("calculateResult", () => {
     });
     expect(result?.message).toBe("😅 你需要加班 3 天補回來");
     expect(result?.netProfit).toBeLessThan(0);
+    expect(result?.workDays).toBe(3);
   });
 
   it("handles monthly salary with profit", () => {
@@ -39,6 +41,7 @@ describe("calculateResult", () => {
     });
     expect(result?.message).toBe("🎉 你可以少工作 7 天");
     expect(result?.netProfit).toBeGreaterThan(0);
+    expect(result?.workDays).toBe(7);
   });
 
   it("handles monthly salary with loss", () => {
@@ -51,6 +54,7 @@ describe("calculateResult", () => {
     });
     expect(result?.message).toBe("😅 你需要加班 7 天補回來");
     expect(result?.netProfit).toBeLessThan(0);
+    expect(result?.workDays).toBe(7);
   });
 
   it("handles hourly salary with profit", () => {
@@ -61,6 +65,7 @@ describe("calculateResult", () => {
     });
     expect(result?.message).toBe("🎉 你可以少工作 1 天");
     expect(result?.netProfit).toBeGreaterThan(0);
+    expect(result?.workDays).toBe(1);
   });
 
   it("handles hourly salary with loss", () => {
@@ -73,5 +78,6 @@ describe("calculateResult", () => {
     });
     expect(result?.message).toBe("😅 你需要加班 1 天補回來");
     expect(result?.netProfit).toBeLessThan(0);
+    expect(result?.workDays).toBe(1);
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -60,5 +60,6 @@ export const calculateResult = (params: {
     cost,
     revenue,
     netProfit,
+    workDays,
   };
 };

--- a/src/types/trade.ts
+++ b/src/types/trade.ts
@@ -1,5 +1,14 @@
 export type SalaryType = "yearly" | "monthly" | "hourly";
 
+export type TradeInput = {
+  buyPrice: number;
+  sellPrice: number;
+  shares: number;
+  salary: number;
+  salaryType: SalaryType;
+  hoursPerDay: number;
+};
+
 export type Result = {
   message: string;
   buyAmount: number;
@@ -10,4 +19,12 @@ export type Result = {
   cost: number;
   revenue: number;
   netProfit: number;
+  workDays: number;
+};
+
+export type TradeRecord = {
+  id: string;
+  createdAt: number;
+  input: TradeInput;
+  result: Result;
 };


### PR DESCRIPTION
## Summary
- add TradeRecord types and extend calculateResult with workDays
- implement new calculation page that saves results to localStorage
- add home page listing saved records with detail dialog and deletion

## Testing
- `npm test`
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6897038f149c8327a611a749e57e8098